### PR TITLE
(GH-6) Update docsy testing for production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ git:
 
 branches:
   only:
-  - docsy-ification # Switch to master once done.
+  - master
 
 install:
   - wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.57.0/hugo_extended_0.57.0_Linux-64bit.deb
@@ -48,4 +48,4 @@ deploy:
     script: bash .travis-ci/deploy.sh
     skip_cleanup: true
     on:
-      branch: docsy-ification # Switch to master once done.
+      branch: master

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# The central Lingua-Pupuli docs site
+
+[![Build Status](https://travis-ci.com/lingua-pupuli/docs.svg?branch=master)](https://travis-ci.com/lingua-pupuli/docs)
 
 ## Cloning
 
@@ -10,8 +13,16 @@ git clone --recurse-submodules https://github.com/lingua-pupuli/docs.git
 To update the Docsy theme use
 
 ```
-git submodule update --init --recursive --depth 1
+git submodule update --init --recursive --depth 50
 ```
+
+## Requirements
+
+- Hugo Extended. See [Docsy Getting Started](https://www.docsy.dev/docs/getting-started/#prerequisites-and-installation) for more information.
+
+For Windows users, chocolatey hosts a [Hugo Extended package](https://chocolatey.org/packages/hugo-extended)
+
+- NodeJS with PostCSS installed.  This is available via `npm install`. See [Docsy Getting Started](https://www.docsy.dev/docs/getting-started/#install-postcss) for more information.
 
 ## Lingua-Pupuli Umbrella Project
 

--- a/vscode/config.toml
+++ b/vscode/config.toml
@@ -2,8 +2,6 @@ baseURL          = "https://puppet-vscode.github.io"
 title            = "Puppet VSCode Extension"
 languageCode     = "en-us"
 
-description = "Language of the Puppet"
-
 enableRobotsTXT = true
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
@@ -54,7 +52,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-# id = "UA-00000000-0"
+id = "UA-74930020-2"
 
 # Language configuration
 


### PR DESCRIPTION
Fixes #6 

---

Previously the deploy tasks and google analytics were disabled during testing.
This commit sets the production values for these tasks.

This commit also removes the description from config.toml as it is from an old
template and has no effect.

---

This commit updates the the README with Travis Badge build information, and more
Getting Started information about Hugo and PostCSS.