### PR TITLE
(maint) Update vscode website with release 0.20.0

### DIFF
--- a/vscode/content/en/blog/releases/0.10.0.md
+++ b/vscode/content/en/blog/releases/0.10.0.md
@@ -20,6 +20,6 @@ github_repo: "" # Disable the edit commands
 - ([GH-214](https://github.com/lingua-pupuli/puppet-vscode/issues/214)) Updated README for PDK `1.3.X`.
 - ([GH-231](https://github.com/lingua-pupuli/puppet-vscode/issues/231)) Make document validation asynchronous.
 
-#### Removed 
+#### Removed
 
 - ([GH-236](https://github.com/lingua-pupuli/puppet-vscode/issues/236)) Remove the preload option.

--- a/vscode/content/en/blog/releases/0.11.0.md
+++ b/vscode/content/en/blog/releases/0.11.0.md
@@ -27,7 +27,7 @@ github_repo: "" # Disable the edit commands
 - ([GH-289](https://github.com/lingua-pupuli/puppet-vscode/issues/289)) Fix Autoindenting for DSL.
 - ([GH-301](https://github.com/lingua-pupuli/puppet-vscode/issues/301)) Fail fast if Puppet Agent is not installed.
 - ([GH-310](https://github.com/lingua-pupuli/puppet-vscode/issues/310)) Fix gulp bump.
-- ([GH-307](https://github.com/lingua-pupuli/puppet-vscode/issues/307)) Fix Path resolution on mac and *nix.
+- ([GH-307](https://github.com/lingua-pupuli/puppet-vscode/issues/307)) Fix Path resolution on mac and \*nix.
 - ([GH-241](https://github.com/lingua-pupuli/puppet-vscode/issues/241)) Ensure specified tcp port is honored.
 - ([GH-296](https://github.com/lingua-pupuli/puppet-vscode/issues/296)) Ensure document file scheme is set.
 - (maint) Fix tslint errors.

--- a/vscode/content/en/blog/releases/0.12.0.md
+++ b/vscode/content/en/blog/releases/0.12.0.md
@@ -14,7 +14,7 @@ github_repo: "" # Disable the edit commands
 
 ### Changed
 
-- ([GH-327](https://github.com/lingua-pupuli/puppet-vscode/issues/327)) Updated Puppet Editor Services to version 0.13.0.  Change Log is at [https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.13.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.13.0)
+- ([GH-327](https://github.com/lingua-pupuli/puppet-vscode/issues/327)) Updated Puppet Editor Services to version 0.13.0. Change Log is at [https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.13.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.13.0)
 - ([GH-316](https://github.com/lingua-pupuli/puppet-vscode/issues/316)) Conform to Keep-A-Changelog format in CHANGELOG
 
 ### Fixed

--- a/vscode/content/en/blog/releases/0.13.0.md
+++ b/vscode/content/en/blog/releases/0.13.0.md
@@ -15,9 +15,9 @@ github_repo: "" # Disable the edit commands
 
 ### Changed
 
-- ([GH-397](https://github.com/lingua-pupuli/puppet-vscode/issues/397)) Updated Puppet Editor Services to version 0.15.0.  Change Log is at [https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.15.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.15.0)
+- ([GH-397](https://github.com/lingua-pupuli/puppet-vscode/issues/397)) Updated Puppet Editor Services to version 0.15.0. Change Log is at [https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.15.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.15.0)
 - ([GH-373](https://github.com/lingua-pupuli/puppet-vscode/issues/373)) Refactor commands and providers to features
-- ([GH-351](https://github.com/lingua-pupuli/puppet-vscode/issues/351)) Updated Puppet Editor Services to version 0.14.0.  Change Log is at [https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.14.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.15.0)
+- ([GH-351](https://github.com/lingua-pupuli/puppet-vscode/issues/351)) Updated Puppet Editor Services to version 0.14.0. Change Log is at [https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.14.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.15.0)
 - ([GH-323](https://github.com/lingua-pupuli/puppet-vscode/issues/323)) Update readme with gif examples
 - ([GH-399](https://github.com/lingua-pupuli/puppet-vscode/issues/399)) Update Puppet loading UI to be more user friendly
 - ([GH-405](https://github.com/lingua-pupuli/puppet-vscode/issues/405)) Update readme with correct links into the readme

--- a/vscode/content/en/blog/releases/0.18.1.md
+++ b/vscode/content/en/blog/releases/0.18.1.md
@@ -21,7 +21,7 @@ github_repo: "" # Disable the edit commands
 ### Fixed
 
 - ([GH-436](https://github.com/lingua-pupuli/puppet-vscode/issues/436)) Fix extension "crash" after editing line of code
-- ([GH-132](https://github.com/lingua-pupuli/puppet-editor-services/issues/132)) [puppet-editor-services-0.19.1](https://github.com/lingua-pupuli/puppet-editor-services/commit/08a2fdaeee59fb9339515122e15fb855e32d6500) Suppress $stdout usage for STDIO transport
+- ([GH-132](https://github.com/lingua-pupuli/puppet-editor-services/issues/132)) [puppet-editor-services-0.19.1](https://github.com/lingua-pupuli/puppet-editor-services/commit/08a2fdaeee59fb9339515122e15fb855e32d6500) Suppress \$stdout usage for STDIO transport
 - ([GH-118](https://github.com/lingua-pupuli/puppet-editor-services/issues/118)) [puppet-editor-services-0.19.1](https://github.com/lingua-pupuli/puppet-editor-services/commit/08a2fdaeee59fb9339515122e15fb855e32d6500) Fail gracefully when critical gems cannot load
 - ([GH-39](https://github.com/lingua-pupuli/puppet-editor-syntax/issues/39)) [puppet-editor-syntax-1.3.2](https://github.com/lingua-pupuli/puppet-editor-syntax/commit/466a37c9fd1241cd679382073087571ac3d96b51) Node definitions can only be strings
 - ([GH-38](https://github.com/lingua-pupuli/puppet-editor-syntax/issues/38)) [puppet-editor-syntax-1.3.2](https://github.com/lingua-pupuli/puppet-editor-syntax/commit/466a37c9fd1241cd679382073087571ac3d96b51) Fix highlighting of classes and functions

--- a/vscode/content/en/blog/releases/0.20.0.md
+++ b/vscode/content/en/blog/releases/0.20.0.md
@@ -1,0 +1,29 @@
+---
+title: "Release 0.20.0"
+linkTitle: "Release 0.20.0"
+date: 2019-08-30
+description: >
+  VSCode Extension Release 0.20.0
+github_repo: "" # Disable the edit commands
+---
+
+### Added
+
+- ([GH-2](https://github.com/lingua-pupuli/docs/issues/2)) [docs-0.1.0](https://github.com/lingua-pupuli/docs/releases/tag/0.1.0) Puppet VSCode Website v1
+- ([GH-534](https://github.com/lingua-pupuli/puppet-vscode/issues/534)) Puppet Module Metadata hover provider
+- ([GH-541](https://github.com/lingua-pupuli/puppet-vscode/issues/541)) Check for latest PDK version and notify
+
+### Changed
+
+- ([GH-546](https://github.com/lingua-pupuli/puppet-vscode/issues/546)) Update Puppet DAG svg icon
+- ([GH-55](https://github.com/lingua-pupuli/puppet-editor-services/issues/55)) [puppet-editor-services-0.21.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.21.0) Allow Debug Server to work with Puppet 6
+- ([GH-106](https://github.com/lingua-pupuli/puppet-editor-services/issues/106)) [puppet-editor-services-0.21.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.21.0) Update puppet-lint to 2.3.6
+
+### Fixed
+
+- ([GH-43](https://github.com/lingua-pupuli/puppet-editor-syntax/issues/43)) [puppet-editor-syntax-1.3.3](https://github.com/lingua-pupuli/puppet-editor-syntax/commit/2ecb3d4b44e7d8b413b91676f39ade0ae0c4b2b4) Fix syntax highlighting for resource references and chain arrows
+- ([GH-34](https://github.com/lingua-pupuli/puppet-editor-syntax/issues/34)) [puppet-editor-syntax-1.3.3](https://github.com/lingua-pupuli/puppet-editor-syntax/commit/2ecb3d4b44e7d8b413b91676f39ade0ae0c4b2b4) Comments in hashes should tokenize
+
+### Deprecated
+
+- [maint] Puppet Docker Protocol deprecated in favor of Microsoft Remote Container Extension

--- a/vscode/content/en/blog/releases/0.5.3.md
+++ b/vscode/content/en/blog/releases/0.5.3.md
@@ -15,6 +15,7 @@ github_repo: "" # Disable the edit commands
 - ([GH-89](https://github.com/lingua-pupuli/puppet-vscode/issues/89)) Documented support for Linux in README.
 
 ### Changed
+
 - ([GH-99](https://github.com/lingua-pupuli/puppet-vscode/issues/99)) Improved client README and Gallery page.
 
 ### Fixed

--- a/vscode/content/en/blog/releases/0.7.0.md
+++ b/vscode/content/en/blog/releases/0.7.0.md
@@ -11,15 +11,17 @@ github_repo: "" # Disable the edit commands
 
 - ([GH-115](https://github.com/lingua-pupuli/puppet-vscode/issues/115)) Add Puppet Development Kit (PDK) integration.
 - ([GH-136](https://github.com/lingua-pupuli/puppet-vscode/issues/136)) Create a better UI experience while Puppet loads.
-- ([GH-61](https://github.com/lingua-pupuli/puppet-vscode/issues/61))  Create a better experience when language client fails.
+- ([GH-61](https://github.com/lingua-pupuli/puppet-vscode/issues/61)) Create a better experience when language client fails.
 - ([GH-122](https://github.com/lingua-pupuli/puppet-vscode/issues/122)) Show upgrade message with changelog.
 - ([GH-120](https://github.com/lingua-pupuli/puppet-vscode/issues/120)) Allow custom Puppet agent installation directory.
 - ([GH-111](https://github.com/lingua-pupuli/puppet-vscode/issues/111)) Parse `puppet-lint.rc` in module directory.
 
 ### Changed
+
 - ([GH-109](https://github.com/lingua-pupuli/puppet-vscode/issues/109)) Randomize languageserver port.
 
 ### Fixed
+
 - ([GH-135](https://github.com/lingua-pupuli/puppet-vscode/issues/135)) Fix incorrect logger when a client error occurs.
 - ([GH-129](https://github.com/lingua-pupuli/puppet-vscode/issues/129)) Honor inline puppet lint directives.
 - ([GH-133](https://github.com/lingua-pupuli/puppet-vscode/issues/133)) Fix issue with puppet 5.1.0.

--- a/vscode/content/en/blog/releases/0.7.1.md
+++ b/vscode/content/en/blog/releases/0.7.1.md
@@ -8,4 +8,5 @@ github_repo: "" # Disable the edit commands
 ---
 
 ### Fixed
+
 - ([GH-157](https://github.com/lingua-pupuli/puppet-vscode/issues/157)) Unhide `Puppet Resource` command in the Command Palette.

--- a/vscode/content/en/blog/releases/0.7.2.md
+++ b/vscode/content/en/blog/releases/0.7.2.md
@@ -8,10 +8,12 @@ github_repo: "" # Disable the edit commands
 ---
 
 ### Added
+
 - ([GH-167](https://github.com/lingua-pupuli/puppet-vscode/issues/167)) Add PDK New Task command.
 - ([GH-156](https://github.com/lingua-pupuli/puppet-vscode/issues/156)) Document restarting Puppet extension command.
 
 ### Changed
+
 - ([GH-88](https://github.com/lingua-pupuli/puppet-vscode/issues/88)) Rework Node Graph Preview to use local svg instead of calling out to the internet.
 - ([GH-154](https://github.com/lingua-pupuli/puppet-vscode/issues/154)) Use hosted JSON schema files instead of vendoring them.
 

--- a/vscode/content/en/docs/Extension Settings.md
+++ b/vscode/content/en/docs/Extension Settings.md
@@ -20,10 +20,6 @@ like to make changes, please create a project issue.
 
 The absolute filepath where the Puppet Editor Service will output the debugging log. By default no logfile is generated
 
-#### puppet.editorService.docker.imageName
-
-The name of the image with tag that contains the Puppet Language server. For example: linguapupuli/puppet-language-server:latest
-
 Default: `linguapupuli/puppet-language-server:latest`
 
 #### puppet.editorService.enable
@@ -36,6 +32,12 @@ Default: `True`
 
 An array of strings of experimental features to enable in the Puppet Editor Service
 
+#### puppet.editorService.hover.showMetadataInfo
+
+Enable or disable showing Puppet Module version information in the metadata.json file
+
+Default: `True`
+
 #### puppet.editorService.loglevel
 
 Set the logging verbosity level for the Puppet Editor Service, with Debug producing the most output and Error producing the least
@@ -46,7 +48,7 @@ Default: `normal`
 
 #### puppet.editorService.protocol
 
-The protocol used to communicate with the Puppet Editor Service.  By default the local STDIO protocol is used
+The protocol used to communicate with the Puppet Editor Service. By default the local STDIO protocol is used. The docker protocol is **DEPRECATED** and will be removed in a future version
 
 Possible values: `stdio`, `tcp`, `docker`
 
@@ -120,6 +122,12 @@ Possible values: `messagebox`, `statusbar`, `none`
 
 Default: `messagebox`
 
+#### puppet.pdk.checkVersion
+
+Enable/disable checking if installed PDK version is latest
+
+Default: `True`
+
 #### puppet.titleBar.pdkNewModule.enable
 
 Enable/disable the PDK New Module icon in the Editor Title Bar
@@ -132,6 +140,10 @@ Default: `True`
 ## Deprecated settings
 
 <!-- Begin Deprecated Settings -->
+#### puppet.editorService.docker.imageName
+
+The name of the image with tag that contains the Puppet Language server. For example: linguapupuli/puppet-language-server:latest
+
 #### puppet.editorService.modulePath
 
 Please use puppet.editorService.puppet.modulePath instead
@@ -170,23 +182,3 @@ Please use puppet.installDirectory instead
 
 
 <!-- End Deprecated Settings -->
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/vscode/update-from-source.ps1
+++ b/vscode/update-from-source.ps1
@@ -97,7 +97,7 @@ function Get-AvailableExtensionSettings($json) {
   $json.contributes.configuration.properties | Get-Member -MemberType NoteProperty | Sort-Object | ForEach-Object {
     $propName = $_.Name
     $property = $json.contributes.configuration.properties."$propName"
-    if ($property.description -notlike '*DEPRECATED*') {
+    if ($property.description -notlike '`*`*DEPRECATED*') {
       $content += "#### $propName`n`n" + $property.description + "`n`n"
     }
 
@@ -118,7 +118,7 @@ function Get-DeprecatedExtensionSettings($json) {
   $json.contributes.configuration.properties | Get-Member -MemberType NoteProperty | Sort-Object | ForEach-Object {
     $propName = $_.Name
     $property = $json.contributes.configuration.properties."$propName"
-    if ($property.description -like '*DEPRECATED*') {
+    if ($property.description -like '`*`*DEPRECATED*') {
       $content += "#### $propName`n`n" + $property.description.replace("**DEPRECATED**", "").Trim() + "`n`n"
     }
   }


### PR DESCRIPTION
This commit updates the vscode website with the 0.20.0 release information.

This is generated from the package.json.