### PR TITLE
(maint) Add Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.148.1/containers/javascript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 14, 12, 10
+ARG VARIANT="14-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# Only useful for debugging the Dockerfile. Ports are forwarded in the devcontainer.json file
+EXPOSE 1313
+
+# Install Hugo
+RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.57.0/hugo_extended_0.57.0_Linux-64bit.deb \
+    && dpkg -i /tmp/hugo.deb
+
+# Install PowerShell
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y powershell

--- a/.devcontainer/PostCreate.ps1
+++ b/.devcontainer/PostCreate.ps1
@@ -1,0 +1,9 @@
+Write-Host "Running npm install ..." -Foreground Yellow
+& npm install
+
+if (-Not (Test-Path './themes/docsy/assets')) {
+  Write-Host "Installing Docsy submodule ..."
+  Push-Location 'themes/docsy'
+  & git submodule update -f --init --recursive --depth 1
+  Pop-Location
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Node.js",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick a Node version: 10, 12, 14
+    "args": { "VARIANT": "14" }
+  },
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [1313],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "pwsh -File .devcontainer/PostCreate.ps1",
+
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "typescript.tsc.autoDetect": "off",
+  "grunt.autoDetect": "off",
+  "jake.autoDetect": "off",
+  "gulp.autoDetect": "off",
+  "npm.autoDetect": "off"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "shell",
+      "command": "hugo",
+      "label": "Run Hugo for Puppet VSCode Docs site",
+      "args": ["server","--source","vscode","--buildDrafts","--buildFuture","--watch","--bind","0.0.0.0"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": false
+      }
+    }
+
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ This hugo site needs the editor-services and editor-syntax site built first, int
 hugo server --bind "0.0.0.0" --source vscode
 ```
 
+### Using VSCode Dev Containers
+
+Due to `fsnotify` not being able to _watch_ Windows mounts inside docker containers, Hugo may not see file changes and will not trigger a rebuild automatically. This is a known problem with Docker/VScode/WSL2/WSL1. To workaround this issue either; do not use Windows to host Linux containers (which is 😢) or use the [Clone in Volume](https://github.com/microsoft/vscode-docs/blob/master/remote-release-notes/v1_47.md#containers-version-01280) feature.
+
 ## Updating the websites from source code
 
 Parts of the websites are automatically generated from source code (e.g. the VS Code `package.json` file). A  PowerShell script has been created to automatically parse the source code, and update the relevant websites.


### PR DESCRIPTION
This commit adds a VSCode Dev Container to the project to make it easier to
develop and make changes to the Puppet VSCode Website